### PR TITLE
:bookmark: release 3.3ctl

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-10-25  Nik Nyby  <nnyby@columbia.edu>
+
+	Fix MutableMapping import
+
 2018-11-30  Nik Nyby  <nnyby@columbia.edu>
 
 	* Added Python 3 compatibility.

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: sorl
-Version: 3.2ctl
+Version: 3.3ctl
 Summary: UNKNOWN
 Home-page: UNKNOWN
 Author: UNKNOWN

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "sorl",
-    version = "3.2ctl",
+    version = "3.3ctl",
     install_requires=[
         "Django",
     ],


### PR DESCRIPTION
To pick up the deprecated import fix from here:
https://github.com/ccnmtl/sorl/pull/4