### PR TITLE
Remove 'ctl' from version

### DIFF
--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: sorl
-Version: 3.3ctl
+Version: 3.3
 Summary: UNKNOWN
 Home-page: UNKNOWN
 Author: UNKNOWN

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "sorl",
-    version = "3.3ctl",
+    version = "3.3",
     install_requires=[
         "Django",
     ],


### PR DESCRIPTION
setuptools complains this isn't a valid version number with 'ctl' at the end.